### PR TITLE
[feat] 팀 등록/수정 페이지 UI 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
         "typescript": "^5.0.2",
-        "vite": "^4.4.5"
+        "vite": "^4.4.5",
+        "vite-tsconfig-paths": "^4.2.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4521,6 +4522,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -6229,6 +6236,26 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/tsconfck": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-2.1.2.tgz",
+      "integrity": "sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==",
+      "dev": true,
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "typescript": "^4.3.5 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
@@ -6488,6 +6515,25 @@
           "optional": true
         },
         "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-4.2.1.tgz",
+      "integrity": "sha512-GNUI6ZgPqT3oervkvzU+qtys83+75N/OuDaQl7HmOqFTb0pjZsuARrRipsyJhJ3enqV8beI1xhGbToR4o78nSQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^2.1.0"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
           "optional": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,19 @@
       "name": "talktudy",
       "version": "0.0.0",
       "dependencies": {
+        "date-fns": "^2.30.0",
         "react": "^18.2.0",
+        "react-datepicker": "^4.20.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.11.0",
+        "react-quill": "^2.0.0",
         "react-router": "^6.16.0",
         "react-router-dom": "^6.16.0",
         "styled-components": "^6.0.8"
       },
       "devDependencies": {
         "@types/react": "^18.2.15",
+        "@types/react-datepicker": "^4.19.0",
         "@types/react-dom": "^18.2.7",
         "@typescript-eslint/eslint-plugin": "^6.7.3",
         "@typescript-eslint/parser": "^6.7.3",
@@ -2579,6 +2584,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.9.0.tgz",
@@ -2815,6 +2829,14 @@
       "integrity": "sha512-FbtmBWCcSa2J4zL781Zf1p5YUBXQomPEcep9QZCfRfQgTxz3pJWiDFLebohZ9fFntX5ibzOkSsrJ0TEew8cAog==",
       "dev": true
     },
+    "node_modules/@types/quill": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+      "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+      "dependencies": {
+        "parchment": "^1.1.2"
+      }
+    },
     "node_modules/@types/react": {
       "version": "18.2.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.23.tgz",
@@ -2824,6 +2846,18 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-datepicker": {
+      "version": "4.19.0",
+      "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-4.19.0.tgz",
+      "integrity": "sha512-461OQou2oHJIfqeTPY+8lBn/V4Z7usmJhcGDWO/R8wQYm+H5/Cqsrwto89J2RTbhWdiynmvh78Beh8txN5y0mA==",
+      "dev": true,
+      "dependencies": {
+        "@popperjs/core": "^2.9.2",
+        "@types/react": "*",
+        "date-fns": "^2.0.1",
+        "react-popper": "^2.2.5"
       }
     },
     "node_modules/@types/react-dom": {
@@ -3398,7 +3432,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -3498,6 +3531,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3583,6 +3629,21 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3599,6 +3660,22 @@
         }
       }
     },
+    "node_modules/deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "dependencies": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3609,7 +3686,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
       "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.1",
         "gopd": "^1.0.1",
@@ -3623,7 +3699,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -4211,11 +4286,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -4385,7 +4475,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4402,7 +4491,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
       "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -4532,7 +4620,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -4585,7 +4672,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
       },
@@ -4597,7 +4683,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4609,7 +4694,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -4621,7 +4705,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.2"
       },
@@ -4692,6 +4775,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4790,7 +4888,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
       "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
       "dependencies": {
         "has-tostringtag": "^1.0.0"
       },
@@ -4907,7 +5004,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -5154,6 +5250,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -5296,7 +5397,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5310,11 +5410,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/object-is": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
+      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5465,6 +5579,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parchment": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+      "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5587,7 +5706,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -5623,6 +5741,32 @@
         }
       ]
     },
+    "node_modules/quill": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+      "dependencies": {
+        "clone": "^2.1.1",
+        "deep-equal": "^1.0.1",
+        "eventemitter3": "^2.0.3",
+        "extend": "^3.0.2",
+        "parchment": "^1.1.4",
+        "quill-delta": "^3.6.2"
+      }
+    },
+    "node_modules/quill-delta": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+      "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+      "dependencies": {
+        "deep-equal": "^1.0.1",
+        "extend": "^3.0.2",
+        "fast-diff": "1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -5632,6 +5776,23 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-datepicker": {
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.20.0.tgz",
+      "integrity": "sha512-I29yHN9SabUDSy7Xq3P8+E8E+D2vyeuYAYYWWjeMisGGtsatltV4CSHodyA7W9z0BuGycc/bhSClDbizx4gZHA==",
+      "dependencies": {
+        "@popperjs/core": "^2.11.8",
+        "classnames": "^2.2.6",
+        "date-fns": "^2.30.0",
+        "prop-types": "^15.7.2",
+        "react-onclickoutside": "^6.13.0",
+        "react-popper": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17 || ^18",
+        "react-dom": "^16.9.0 || ^17 || ^18"
       }
     },
     "node_modules/react-dom": {
@@ -5646,11 +5807,64 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
+    },
+    "node_modules/react-icons": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-onclickoutside": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
+      "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/react-onclickoutside/blob/master/FUNDING.md"
+      },
+      "peerDependencies": {
+        "react": "^15.5.x || ^16.x || ^17.x || ^18.x",
+        "react-dom": "^15.5.x || ^16.x || ^17.x || ^18.x"
+      }
+    },
+    "node_modules/react-popper": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.3.0.tgz",
+      "integrity": "sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==",
+      "dependencies": {
+        "react-fast-compare": "^3.0.1",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.0.0",
+        "react": "^16.8.0 || ^17 || ^18",
+        "react-dom": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-quill": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+      "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+      "dependencies": {
+        "@types/quill": "^1.3.10",
+        "lodash": "^4.17.4",
+        "quill": "^1.3.7"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
     },
     "node_modules/react-router": {
       "version": "6.16.0",
@@ -5747,7 +5961,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
       "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
-      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.2.0",
@@ -5953,7 +6166,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
       "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "functions-have-names": "^1.2.3",
@@ -6536,6 +6748,14 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -12,14 +12,19 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "date-fns": "^2.30.0",
     "react": "^18.2.0",
+    "react-datepicker": "^4.20.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.11.0",
+    "react-quill": "^2.0.0",
     "react-router": "^6.16.0",
     "react-router-dom": "^6.16.0",
     "styled-components": "^6.0.8"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",
+    "@types/react-datepicker": "^4.19.0",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",
     "typescript": "^5.0.2",
-    "vite": "^4.4.5"
+    "vite": "^4.4.5",
+    "vite-tsconfig-paths": "^4.2.1"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,21 @@
-import React from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { Header } from './components/index';
-import { MainPage, LoginPage, DetailPage, DetailPage_owner } from './pages/index';
+import { MainPage, LoginPage, DetailPage, DetailPage_owner, RegisterPage } from './pages/index';
 import './global.css';
 
 function App() {
 	return (
 		<>
 			<Header />
-			<Routes>
-				<Route path='/' element={<MainPage />} />
-				<Route path='/login' element={<LoginPage />} />
-				<Route path='/detail' element={<DetailPage />} />
-				<Route path='/detail/own' element={<DetailPage_owner />} />
-			</Routes>
+			<main>
+				<Routes>
+					<Route path='/' element={<MainPage />} />
+					<Route path='/register' element={<RegisterPage />} />
+					<Route path='/login' element={<LoginPage />} />
+					<Route path='/detail' element={<DetailPage />} />
+					<Route path='/detail/own' element={<DetailPage_owner />} />
+				</Routes>
+			</main>
 		</>
 	);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,14 @@
 import { Route, Routes } from 'react-router-dom';
-import { Header } from './components/index';
-import { MainPage, LoginPage, DetailPage, DetailPage_owner, RegisterPage } from './pages/index';
+
+import { Header } from '@components/index';
+import {
+	MainPage,
+	LoginPage,
+	DetailPage,
+	DetailPage_owner,
+	RegisterPage,
+	EditPage,
+} from '@pages/index';
 import './global.css';
 
 function App() {
@@ -11,6 +19,7 @@ function App() {
 				<Routes>
 					<Route path='/' element={<MainPage />} />
 					<Route path='/register' element={<RegisterPage />} />
+					<Route path=':boardId/edit' element={<EditPage />} />
 					<Route path='/login' element={<LoginPage />} />
 					<Route path='/detail' element={<DetailPage />} />
 					<Route path='/detail/own' element={<DetailPage_owner />} />

--- a/src/components/BoardListForm.tsx
+++ b/src/components/BoardListForm.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react';
+
+import { BsCalendarEvent } from 'react-icons/bs';
+import { ko } from 'date-fns/esm/locale';
+import ReactQuill from 'react-quill';
+import DatePicker from 'react-datepicker';
+import styled, { css } from 'styled-components';
+
+import { StyledStack } from '@/components/Stack';
+import Icon from '@/components/Icon';
+import Editor from '@/components/Editor';
+
+import 'react-datepicker/dist/react-datepicker.css';
+
+const today = new Date();
+const tomorrow = new Date(today);
+tomorrow.setDate(today.getDate() + 1);
+
+const BoardListForm = () => {
+	const [endDate, setEndDate] = useState<Date>(tomorrow);
+	const [editor, setEditor] = useState<ReactQuill.Value>('');
+
+	return (
+		<FormWrapper>
+			<FormField $align='center' $mb={10}>
+				<label htmlFor='type'>모집 구분</label>
+				<select name='type' id='type'>
+					<option value='1'>스터디</option>
+					<option value='2'>채팅</option>
+				</select>
+			</FormField>
+			<FormField $align='center' $mb={10}>
+				<label htmlFor='position'>모집 포지션</label>
+				<select name='position' id='position'>
+					<option value='NONE'>선택안함</option>
+					<option value='FRONTEND'>프론트엔드</option>
+					<option value='BACKEND'>백엔드</option>
+					<option value='FULLSTACK'>풀스택</option>
+					<option value='ANDROID'>안드로이드</option>
+					<option value='IOS'>IOS</option>
+					<option value='PM'>PM</option>
+					<option value='DESIGNER'>디자이너</option>
+				</select>
+			</FormField>
+			<FormField $align='center' $mb={10}>
+				<label htmlFor='endDate'>모집 마감일</label>
+				<Calendar>
+					<DatePicker
+						dateFormat='yyyy-MM-dd'
+						selected={endDate}
+						onChange={date => date && setEndDate(date)}
+						locale={ko}
+					/>
+					<Icon className='icon' $size={32} $iconColor='#000'>
+						<BsCalendarEvent />
+					</Icon>
+				</Calendar>
+			</FormField>
+			<FormField $align='center' $mb={10}>
+				<label htmlFor='team'>모집 인원</label>
+				<select name='team' id='team'>
+					<option value='1'>1명</option>
+					<option value='2'>2명</option>
+					<option value='3'>3명</option>
+					<option value='4'>4명</option>
+					<option value='5'>5명</option>
+					<option value='6'>6명</option>
+					<option value='7'>7명</option>
+					<option value='8'>8명</option>
+					<option value='9'>9명</option>
+				</select>
+			</FormField>
+			<FormField $direction='column' $mb={10} $fieldWidth={100} $gap={10}>
+				<label htmlFor='title'>제목</label>
+				<input type='text' name='title' value='' placeholder='제목을 입력해 주세요.' />
+			</FormField>
+			<EditorFormField $direction='column' $mb={10}>
+				<Editor html={editor} setHtml={setEditor} />
+				<label htmlFor='tags' className='srOnly'>
+					태그 모음
+				</label>
+				<input type='text' name='tags' value='' placeholder='#태그입력' />
+			</EditorFormField>
+			<SubmitButton>등록하기</SubmitButton>
+		</FormWrapper>
+	);
+};
+
+export default BoardListForm;
+
+const FormWrapper = styled.form`
+	max-width: 600px;
+	margin: 0 auto;
+	padding: 20px 10px;
+`;
+
+const FormField = styled(StyledStack)<{ $gap?: number; $fieldWidth?: number }>`
+	${props =>
+		props.$gap &&
+		css`
+			label {
+				${props.$direction === 'row' ? 'margin-right' : 'margin-bottom'}: ${props.$gap}px;
+			}
+		`}
+
+	label {
+		display: block;
+		min-width: 140px;
+		font-weight: 500;
+		text-align: left;
+	}
+
+	select,
+	input {
+		width: ${props => (props.$fieldWidth ? `${props.$fieldWidth}%` : '200px')};
+		padding: 6px 8px;
+		border: 1px solid #c1c1c1;
+		border-radius: 4px;
+	}
+
+	select:focus,
+	input:focus {
+		border-color: #3e86f5;
+		outline: #3e86f5;
+	}
+`;
+
+const EditorFormField = styled(StyledStack)`
+	border: 1px solid #c1c1c1;
+	border-radius: 4px;
+
+	.editor {
+		width: 100%;
+		border: none;
+	}
+
+	.ql-toolbar.ql-snow,
+	.ql-container.ql-snow {
+		position: relative;
+		border: none;
+	}
+
+	.ql-container.ql-snow {
+		min-height: 400px;
+	}
+
+	.ql-container.ql-snow::before,
+	.ql-container.ql-snow::after {
+		position: absolute;
+		left: 50%;
+		width: 96%;
+		height: 0.5px;
+		background-color: #c1c1c1;
+		transform: translateX(-50%);
+		content: '';
+	}
+
+	.ql-container.ql-snow::before {
+		top: 0;
+	}
+
+	.ql-container.ql-snow::after {
+		bottom: 0;
+	}
+
+	input {
+		position: relative;
+		top: -3px;
+		width: 100%;
+		padding: 8px 16px;
+		border: none;
+		outline: none;
+		background-color: transparent;
+	}
+`;
+
+const Calendar = styled.div`
+	position: relative;
+
+	.icon {
+		position: absolute;
+		top: 0;
+		right: -5px;
+		pointer-events: none;
+		z-index: 222;
+	}
+`;
+
+const SubmitButton = styled.button`
+	width: 100%;
+	padding: 10px;
+	border: none;
+	border-radius: 4px;
+	color: #fff;
+	background-color: #f8c332;
+	font-weight: 700;
+	font-size: 14px;
+`;

--- a/src/components/BoardListForm.tsx
+++ b/src/components/BoardListForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+import { useLocation } from 'react-router';
 import { BsCalendarEvent } from 'react-icons/bs';
 import { ko } from 'date-fns/esm/locale';
 import ReactQuill from 'react-quill';
@@ -17,6 +18,9 @@ const tomorrow = new Date(today);
 tomorrow.setDate(today.getDate() + 1);
 
 const BoardListForm = () => {
+	const location = useLocation();
+	const isEditPage = location.pathname.includes('edit');
+
 	const [endDate, setEndDate] = useState<Date>(tomorrow);
 	const [editor, setEditor] = useState<ReactQuill.Value>('');
 
@@ -81,12 +85,23 @@ const BoardListForm = () => {
 				</label>
 				<input type='text' name='tags' value='' placeholder='#태그입력' />
 			</EditorFormField>
-			<SubmitButton>등록하기</SubmitButton>
+			<SubmitButton>{isEditPage ? '수정하기' : '등록하기'}</SubmitButton>
 		</FormWrapper>
 	);
 };
 
 export default BoardListForm;
+
+export const FormHeader = styled(StyledStack)`
+	max-width: 600px;
+	margin: 0 auto;
+	border-bottom: 1px solid #ddd;
+`;
+
+export const FormTitle = styled.h2`
+	margin-right: 8px;
+	font-size: 20px;
+`;
 
 const FormWrapper = styled.form`
 	max-width: 600px;

--- a/src/components/ContentWrapper.tsx
+++ b/src/components/ContentWrapper.tsx
@@ -1,0 +1,13 @@
+import { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+const ContentWrapper = ({ children }: PropsWithChildren) => {
+	return <Wrapper>{children}</Wrapper>;
+};
+
+export default ContentWrapper;
+
+const Wrapper = styled.div`
+	width: 1280px;
+	margin: 0 auto;
+`;

--- a/src/components/ContentWrapper.tsx
+++ b/src/components/ContentWrapper.tsx
@@ -10,4 +10,5 @@ export default ContentWrapper;
 const Wrapper = styled.div`
 	width: 1280px;
 	margin: 0 auto;
+	padding: 20px 0;
 `;

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -1,0 +1,83 @@
+import { useRef } from 'react';
+import ReactQuill from 'react-quill';
+
+import 'react-quill/dist/quill.snow.css';
+
+interface Editor {
+	html: ReactQuill.Value;
+	setHtml: React.Dispatch<React.SetStateAction<ReactQuill.Value>>;
+}
+
+const Editor = ({ html, setHtml }: Editor) => {
+	const quillRef = useRef<ReactQuill | null>(null);
+
+	const modules = {
+		toolbar: {
+			container: [
+				[{ header: [1, 2, 3, 4, 5, 6, false] }],
+				[{ font: [] }],
+				[{ align: [] }],
+				['bold', 'italic', 'underline', 'strike', 'blockquote'],
+				[{ list: 'ordered' }, { list: 'bullet' }, 'link'],
+				[
+					{
+						color: [
+							'#000000',
+							'#e60000',
+							'#ff9900',
+							'#ffff00',
+							'#008a00',
+							'#0066cc',
+							'#9933ff',
+							'#ffffff',
+							'#facccc',
+							'#ffebcc',
+							'#ffffcc',
+							'#cce8cc',
+							'#cce0f5',
+							'#ebd6ff',
+							'#bbbbbb',
+							'#f06666',
+							'#ffc266',
+							'#ffff66',
+							'#66b966',
+							'#66a3e0',
+							'#c285ff',
+							'#888888',
+							'#a10000',
+							'#b26b00',
+							'#b2b200',
+							'#006100',
+							'#0047b2',
+							'#6b24b2',
+							'#444444',
+							'#5c0000',
+							'#663d00',
+							'#666600',
+							'#003700',
+							'#002966',
+							'#3d1466',
+							'custom-color',
+						],
+					},
+					{ background: [] },
+				],
+				['image'],
+				['clean'],
+			],
+		},
+	};
+
+	return (
+		<ReactQuill
+			theme='snow'
+			ref={quillRef}
+			onChange={setHtml}
+			value={html}
+			className='editor'
+			modules={modules}
+		/>
+	);
+};
+
+export default Editor;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,6 +29,7 @@ const Header: React.FC<HeaderProps> = ({ isLoggedIn }) => {
 					<>
 						{/* <AlarmIcon />
 						<UserIcon /> */}
+						<Link to='/register'>새 글 쓰기</Link>
 					</>
 				) : (
 					<>

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,0 +1,67 @@
+import styled, { css } from 'styled-components';
+
+interface IconStyledProps {
+	$variants?: 'lined' | 'filled';
+	$radius?: number;
+	$containerColor?: string;
+	$iconColor: string;
+	$size?: number;
+	$fontSize?: number;
+	$mr?: number;
+	$mb?: number;
+}
+
+// NOTE: React-icons를 자식 컴포넌트로 받아옴
+interface Icon extends IconStyledProps {
+	className?: string;
+	children: React.ReactNode;
+}
+
+const Icon = ({ className, children, ...props }: Icon) => {
+	return (
+		<StyledIcon {...props} className={className}>
+			{children}
+		</StyledIcon>
+	);
+};
+
+export default Icon;
+
+const StyledIcon = styled.div<IconStyledProps>`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	color: ${props => props.$iconColor};
+	font-size: ${props => (props.$fontSize ? `${props.$fontSize}px` : '12px')};
+	${props =>
+		props.$variants === 'lined' &&
+		css`
+			border: 1px solid ${props.$containerColor};
+		`};
+	${props =>
+		props.$variants === 'filled' &&
+		css`
+			background-color: ${props.$containerColor};
+		`};
+	${props =>
+		props.$radius &&
+		css`
+			border-radius: ${props.$radius}px;
+		`};
+	${props =>
+		props.$size &&
+		css`
+			width: ${props.$size}px;
+			height: ${props.$size}px;
+		`};
+	${props =>
+		props.$mr &&
+		css`
+			margin-right: ${props.$mr}px;
+		`};
+	${props =>
+		props.$mb &&
+		css`
+			margin-bottom: ${props.$mb}px;
+		`};
+`;

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -1,0 +1,60 @@
+import styled, { css } from 'styled-components';
+
+interface StackStyledProps {
+	$direction?: 'row' | 'column';
+	$justify?:
+		| 'flex-start'
+		| 'center'
+		| 'flex-end'
+		| 'space-between'
+		| 'space-around'
+		| 'space-evenly';
+	$align?: 'flex-start' | 'center' | 'flex-end';
+	$mb?: number;
+	$mr?: number;
+	$py?: number;
+	$px?: number;
+}
+
+interface Stack extends StackStyledProps {
+	children: React.ReactNode;
+}
+
+const Stack = ({ children, ...props }: Stack) => {
+	return <StyledStack {...props}>{children}</StyledStack>;
+};
+
+export default Stack;
+
+export const StyledStack = styled.div<StackStyledProps>`
+	display: flex;
+	${props =>
+		props.$direction &&
+		css`
+			flex-direction: ${props.$direction};
+		`}
+	justify-content: ${props => props.$justify || 'flex-start'};
+	align-items: ${props => props.$align || 'flex-start'};
+	${props =>
+		props.$py &&
+		css`
+			padding-top: ${props.$py}px;
+			padding-bottom: ${props.$py}px;
+		`}
+	${props =>
+		props.$px &&
+		css`
+			padding-left: ${props.$px}px;
+			padding-right: ${props.$px}px;
+		`}
+	${props =>
+		props.$mb &&
+		css`
+			margin-bottom: ${props.$mb}px;
+		`}
+    ${props =>
+		props.$mr &&
+		css`
+			margin-right: ${props.$mr}px;
+		`}
+`;

--- a/src/global.css
+++ b/src/global.css
@@ -1,124 +1,118 @@
-html,
 body,
-div,
-span,
-applet,
-object,
-iframe,
+p,
 h1,
 h2,
 h3,
 h4,
 h5,
 h6,
-p,
-blockquote,
-pre,
-a,
-abbr,
-acronym,
-address,
-big,
-cite,
-code,
-del,
-dfn,
-em,
-img,
-ins,
-kbd,
-q,
-s,
-samp,
-small,
-strike,
-strong,
-sub,
-sup,
-tt,
-var,
-b,
-u,
-i,
-center,
+ul,
+ol,
+li,
 dl,
 dt,
 dd,
-ol,
-ul,
-li,
-fieldset,
-form,
-label,
-legend,
 table,
-caption,
-tbody,
-tfoot,
-thead,
-tr,
 th,
 td,
-article,
-aside,
-canvas,
-details,
-embed,
-figure,
-figcaption,
-footer,
-header,
-hgroup,
-menu,
-nav,
-output,
-ruby,
-section,
-summary,
-time,
-mark,
-audio,
-video {
+form,
+fieldset,
+legend,
+input,
+textarea,
+button,
+select {
 	margin: 0;
 	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+	box-sizing: border-box;
 }
-/* HTML5 display-role reset for older browsers */
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-menu,
-nav,
-section {
-	display: block;
-}
-body {
-	line-height: 1;
-}
+
 ol,
 ul {
 	list-style: none;
 }
-blockquote,
-q {
-	quotes: none;
-}
-blockquote:before,
-blockquote:after,
-q:before,
-q:after {
-	content: '';
-	content: none;
-}
+
 table {
 	border-collapse: collapse;
 	border-spacing: 0;
+}
+
+button {
+	cursor: pointer;
+}
+
+/* FONTS */
+
+@font-face {
+	font-family: 'SpoqaHanSansNeo';
+	font-weight: 700;
+	src: url('https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Bold.woff2')
+		format('woff2');
+}
+
+@font-face {
+	font-family: 'SpoqaHanSansNeo';
+	font-weight: 500;
+	src: url('https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Medium.woff2')
+		format('woff2');
+}
+
+@font-face {
+	font-family: 'SpoqaHanSansNeo';
+	font-weight: 400;
+	src: url('https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@latest/Subset/SpoqaHanSansNeo/SpoqaHanSansNeo-Regular.woff2')
+		format('woff2');
+}
+
+body {
+	font-family: SpoqaHanSansNeo, -apple-system, BlinkMacSystemFont, 'Malgun Gothic',
+		'Apple SD Gothic Neo', sans-serif;
+}
+
+input,
+textarea,
+select,
+button {
+	font-family: inherit;
+}
+
+/* COMMON */
+
+.srOnly {
+	position: absolute;
+	clip: rect(0 0 0 0);
+	width: 1px;
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+}
+
+.react-datepicker__day--selected,
+.react-datepicker__day--in-selecting-range,
+.react-datepicker__day--in-range,
+.react-datepicker__month-text--selected,
+.react-datepicker__month-text--in-selecting-range,
+.react-datepicker__month-text--in-range,
+.react-datepicker__quarter-text--selected,
+.react-datepicker__quarter-text--in-selecting-range,
+.react-datepicker__quarter-text--in-range,
+.react-datepicker__year-text--selected,
+.react-datepicker__year-text--in-selecting-range,
+.react-datepicker__year-text--in-range {
+	background-color: #f8c332;
+}
+
+.react-datepicker__day--selected:hover,
+.react-datepicker__day--in-selecting-range:hover,
+.react-datepicker__day--in-range:hover,
+.react-datepicker__month-text--selected:hover,
+.react-datepicker__month-text--in-selecting-range:hover,
+.react-datepicker__month-text--in-range:hover,
+.react-datepicker__quarter-text--selected:hover,
+.react-datepicker__quarter-text--in-selecting-range:hover,
+.react-datepicker__quarter-text--in-range:hover,
+.react-datepicker__year-text--selected:hover,
+.react-datepicker__year-text--in-selecting-range:hover,
+.react-datepicker__year-text--in-range:hover {
+	background-color: #fed155;
 }

--- a/src/pages/EditPage.tsx
+++ b/src/pages/EditPage.tsx
@@ -1,0 +1,28 @@
+import { BsPencil } from 'react-icons/bs';
+
+import BoardListForm, { FormHeader, FormTitle } from '@/components/BoardListForm';
+import ContentWrapper from '@components/ContentWrapper';
+import Icon from '@/components/Icon';
+
+const EditPage = () => {
+	return (
+		<ContentWrapper>
+			<FormHeader $align='center' $py={10} $px={10} $mb={20}>
+				<Icon
+					$variants='filled'
+					$size={24}
+					$radius={4}
+					$containerColor='#f8c332'
+					$iconColor='#fff'
+					$mr={10}
+				>
+					<BsPencil />
+				</Icon>
+				<FormTitle>[작성한 글 타이틀] 폼 수정</FormTitle>
+			</FormHeader>
+			<BoardListForm />
+		</ContentWrapper>
+	);
+};
+
+export default EditPage;

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,0 +1,73 @@
+import { BsPencil } from 'react-icons/bs';
+import ContentWrapper from '@components/ContentWrapper';
+
+const RegisterPage = () => {
+	return (
+		<ContentWrapper>
+			<div>
+				<BsPencil />
+				<h2>팀원 모집 폼</h2>
+				<span>팀원을 모집하기 위해 필요한 정보이니 꼼꼼하게 입력해주세요.</span>
+			</div>
+			<form>
+				<div>
+					<label htmlFor='type'>모집 구분</label>
+					<button type='button'>선택해 주세요</button>
+					<ul>
+						<li>스터디</li>
+						<li>채팅</li>
+					</ul>
+					<input type='hidden' name='type' value='' />
+				</div>
+				<div>
+					<label htmlFor='position'>모집 포지션</label>
+					<button type='button'>선택해 주세요</button>
+					<ul>
+						<li>선택안함</li>
+						<li>프론트엔드</li>
+						<li>백엔드</li>
+						<li>풀스택</li>
+						<li>안드로이드</li>
+						<li>IOS</li>
+						<li>PM</li>
+						<li>디자이너</li>
+					</ul>
+					<input type='hidden' name='position' value='' />
+				</div>
+				<div>
+					<label htmlFor='endData'>모집 마감일</label>
+					<button type='button'>모집 마감일</button>
+					{/* 달력UI */}
+					<input type='hidden' name='endData' value='' />
+				</div>
+				<div>
+					<label htmlFor='team'>모집 인원</label>
+					<button type='button'>모집 마감일</button>
+					<ul>
+						<li>1명</li>
+						<li>2명</li>
+						<li>3명</li>
+						<li>4명</li>
+						<li>5명</li>
+						<li>6명</li>
+						<li>7명</li>
+						<li>8명</li>
+						<li>9명</li>
+					</ul>
+					<input type='hidden' name='team' value='' />
+				</div>
+				<div>
+					<label htmlFor='title'>제목</label>
+					<input type='text' name='title' value='' placeholder='제목을 입력해 주세요.' />
+				</div>
+				<div>
+					{/* 에디터 */}
+					<label htmlFor='tags'></label>
+					<input type='text' name='tags' value='' placeholder='#태그입력' />
+				</div>
+			</form>
+		</ContentWrapper>
+	);
+};
+
+export default RegisterPage;

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,26 +1,12 @@
-import { useState } from 'react';
-import { BsPencil, BsCalendarEvent } from 'react-icons/bs';
-import ReactQuill from 'react-quill';
-import DatePicker from 'react-datepicker';
-import { ko } from 'date-fns/esm/locale';
-
-import styled, { css } from 'styled-components';
+import { BsPencil } from 'react-icons/bs';
+import styled from 'styled-components';
 
 import ContentWrapper from '@components/ContentWrapper';
 import { StyledStack } from '@/components/Stack';
 import Icon from '@/components/Icon';
-import Editor from '@/components/Editor';
-
-import 'react-datepicker/dist/react-datepicker.css';
-
-const today = new Date();
-const tomorrow = new Date(today);
-tomorrow.setDate(today.getDate() + 1);
+import BoardListForm from '@/components/BoardListForm';
 
 const RegisterPage = () => {
-	const [endDate, setEndDate] = useState<Date>(tomorrow);
-	const [editor, setEditor] = useState<ReactQuill.Value>('');
-
 	return (
 		<ContentWrapper>
 			<RegisterHeader $align='center' $py={10} $px={10} $mb={20}>
@@ -37,68 +23,7 @@ const RegisterPage = () => {
 				<Title>팀원 모집 폼</Title>
 				<TitleCaption>팀원을 모집하기 위해 필요한 정보이니 꼼꼼하게 입력해주세요.</TitleCaption>
 			</RegisterHeader>
-			<RegisterForm>
-				<RegisterFormField $align='center' $mb={10}>
-					<label htmlFor='type'>모집 구분</label>
-					<select name='type' id='type'>
-						<option value='1'>스터디</option>
-						<option value='2'>채팅</option>
-					</select>
-				</RegisterFormField>
-				<RegisterFormField $align='center' $mb={10}>
-					<label htmlFor='position'>모집 포지션</label>
-					<select name='position' id='position'>
-						<option value='NONE'>선택안함</option>
-						<option value='FRONTEND'>프론트엔드</option>
-						<option value='BACKEND'>백엔드</option>
-						<option value='FULLSTACK'>풀스택</option>
-						<option value='ANDROID'>안드로이드</option>
-						<option value='IOS'>IOS</option>
-						<option value='PM'>PM</option>
-						<option value='DESIGNER'>디자이너</option>
-					</select>
-				</RegisterFormField>
-				<RegisterFormField $align='center' $mb={10}>
-					<label htmlFor='endDate'>모집 마감일</label>
-					<Calendar>
-						<DatePicker
-							dateFormat='yyyy-MM-dd'
-							selected={endDate}
-							onChange={date => date && setEndDate(date)}
-							locale={ko}
-						/>
-						<Icon className='icon' $size={32} $iconColor='#000'>
-							<BsCalendarEvent />
-						</Icon>
-					</Calendar>
-				</RegisterFormField>
-				<RegisterFormField $align='center' $mb={10}>
-					<label htmlFor='team'>모집 인원</label>
-					<select name='team' id='team'>
-						<option value='1'>1명</option>
-						<option value='2'>2명</option>
-						<option value='3'>3명</option>
-						<option value='4'>4명</option>
-						<option value='5'>5명</option>
-						<option value='6'>6명</option>
-						<option value='7'>7명</option>
-						<option value='8'>8명</option>
-						<option value='9'>9명</option>
-					</select>
-				</RegisterFormField>
-				<RegisterFormField $direction='column' $mb={10} $fieldWidth={100} $gap={10}>
-					<label htmlFor='title'>제목</label>
-					<input type='text' name='title' value='' placeholder='제목을 입력해 주세요.' />
-				</RegisterFormField>
-				<EditorFormField $direction='column' $mb={10}>
-					<Editor html={editor} setHtml={setEditor} />
-					<label htmlFor='tags' className='srOnly'>
-						태그 모음
-					</label>
-					<input type='text' name='tags' value='' placeholder='#태그입력' />
-				</EditorFormField>
-				<SubmitButton>등록하기</SubmitButton>
-			</RegisterForm>
+			<BoardListForm />
 		</ContentWrapper>
 	);
 };
@@ -120,113 +45,4 @@ const TitleCaption = styled.span`
 	color: #c1c1c1;
 	font-size: 13px;
 	align-self: end;
-`;
-
-const RegisterForm = styled.form`
-	max-width: 600px;
-	margin: 0 auto;
-	padding: 20px 10px;
-`;
-
-const RegisterFormField = styled(StyledStack)<{ $gap?: number; $fieldWidth?: number }>`
-	${props =>
-		props.$gap &&
-		css`
-			label {
-				${props.$direction === 'row' ? 'margin-right' : 'margin-bottom'}: ${props.$gap}px;
-			}
-		`}
-
-	label {
-		display: block;
-		min-width: 140px;
-		font-weight: 500;
-		text-align: left;
-	}
-
-	select,
-	input {
-		width: ${props => (props.$fieldWidth ? `${props.$fieldWidth}%` : '200px')};
-		padding: 6px 8px;
-		border: 1px solid #c1c1c1;
-		border-radius: 4px;
-	}
-
-	select:focus,
-	input:focus {
-		border-color: #3e86f5;
-		outline: #3e86f5;
-	}
-`;
-
-const EditorFormField = styled(StyledStack)`
-	border: 1px solid #c1c1c1;
-	border-radius: 4px;
-
-	.editor {
-		width: 100%;
-		border: none;
-	}
-
-	.ql-toolbar.ql-snow,
-	.ql-container.ql-snow {
-		position: relative;
-		border: none;
-	}
-
-	.ql-container.ql-snow {
-		min-height: 400px;
-	}
-
-	.ql-container.ql-snow::before,
-	.ql-container.ql-snow::after {
-		position: absolute;
-		left: 50%;
-		width: 96%;
-		height: 0.5px;
-		background-color: #c1c1c1;
-		transform: translateX(-50%);
-		content: '';
-	}
-
-	.ql-container.ql-snow::before {
-		top: 0;
-	}
-
-	.ql-container.ql-snow::after {
-		bottom: 0;
-	}
-
-	input {
-		position: relative;
-		top: -3px;
-		width: 100%;
-		padding: 8px 16px;
-		border: none;
-		outline: none;
-		background-color: transparent;
-	}
-`;
-
-const Calendar = styled.div`
-	position: relative;
-
-	.icon {
-		position: absolute;
-		top: 0;
-		right: -5px;
-		pointer-events: none;
-		z-index: 222;
-	}
-`;
-
-const SubmitButton = styled.button`
-	width: 100%;
-	padding: 10px;
-	border: none;
-	border-radius: 4px;
-	color: #fff;
-	background-color: #f8c332;
-	font-weight: 700;
-	font-size: 14px;
 `;

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,73 +1,232 @@
-import { BsPencil } from 'react-icons/bs';
+import { useState } from 'react';
+import { BsPencil, BsCalendarEvent } from 'react-icons/bs';
+import ReactQuill from 'react-quill';
+import DatePicker from 'react-datepicker';
+import { ko } from 'date-fns/esm/locale';
+
+import styled, { css } from 'styled-components';
+
 import ContentWrapper from '@components/ContentWrapper';
+import { StyledStack } from '@/components/Stack';
+import Icon from '@/components/Icon';
+import Editor from '@/components/Editor';
+
+import 'react-datepicker/dist/react-datepicker.css';
+
+const today = new Date();
+const tomorrow = new Date(today);
+tomorrow.setDate(today.getDate() + 1);
 
 const RegisterPage = () => {
+	const [endDate, setEndDate] = useState<Date>(tomorrow);
+	const [editor, setEditor] = useState<ReactQuill.Value>('');
+
 	return (
 		<ContentWrapper>
-			<div>
-				<BsPencil />
-				<h2>팀원 모집 폼</h2>
-				<span>팀원을 모집하기 위해 필요한 정보이니 꼼꼼하게 입력해주세요.</span>
-			</div>
-			<form>
-				<div>
+			<RegisterHeader $align='center' $py={10} $px={10} $mb={20}>
+				<Icon
+					$variants='filled'
+					$size={24}
+					$radius={4}
+					$containerColor='#f8c332'
+					$iconColor='#fff'
+					$mr={10}
+				>
+					<BsPencil />
+				</Icon>
+				<Title>팀원 모집 폼</Title>
+				<TitleCaption>팀원을 모집하기 위해 필요한 정보이니 꼼꼼하게 입력해주세요.</TitleCaption>
+			</RegisterHeader>
+			<RegisterForm>
+				<RegisterFormField $align='center' $mb={10}>
 					<label htmlFor='type'>모집 구분</label>
-					<button type='button'>선택해 주세요</button>
-					<ul>
-						<li>스터디</li>
-						<li>채팅</li>
-					</ul>
-					<input type='hidden' name='type' value='' />
-				</div>
-				<div>
+					<select name='type' id='type'>
+						<option value='1'>스터디</option>
+						<option value='2'>채팅</option>
+					</select>
+				</RegisterFormField>
+				<RegisterFormField $align='center' $mb={10}>
 					<label htmlFor='position'>모집 포지션</label>
-					<button type='button'>선택해 주세요</button>
-					<ul>
-						<li>선택안함</li>
-						<li>프론트엔드</li>
-						<li>백엔드</li>
-						<li>풀스택</li>
-						<li>안드로이드</li>
-						<li>IOS</li>
-						<li>PM</li>
-						<li>디자이너</li>
-					</ul>
-					<input type='hidden' name='position' value='' />
-				</div>
-				<div>
-					<label htmlFor='endData'>모집 마감일</label>
-					<button type='button'>모집 마감일</button>
-					{/* 달력UI */}
-					<input type='hidden' name='endData' value='' />
-				</div>
-				<div>
+					<select name='position' id='position'>
+						<option value='NONE'>선택안함</option>
+						<option value='FRONTEND'>프론트엔드</option>
+						<option value='BACKEND'>백엔드</option>
+						<option value='FULLSTACK'>풀스택</option>
+						<option value='ANDROID'>안드로이드</option>
+						<option value='IOS'>IOS</option>
+						<option value='PM'>PM</option>
+						<option value='DESIGNER'>디자이너</option>
+					</select>
+				</RegisterFormField>
+				<RegisterFormField $align='center' $mb={10}>
+					<label htmlFor='endDate'>모집 마감일</label>
+					<Calendar>
+						<DatePicker
+							dateFormat='yyyy-MM-dd'
+							selected={endDate}
+							onChange={date => date && setEndDate(date)}
+							locale={ko}
+						/>
+						<Icon className='icon' $size={32} $iconColor='#000'>
+							<BsCalendarEvent />
+						</Icon>
+					</Calendar>
+				</RegisterFormField>
+				<RegisterFormField $align='center' $mb={10}>
 					<label htmlFor='team'>모집 인원</label>
-					<button type='button'>모집 마감일</button>
-					<ul>
-						<li>1명</li>
-						<li>2명</li>
-						<li>3명</li>
-						<li>4명</li>
-						<li>5명</li>
-						<li>6명</li>
-						<li>7명</li>
-						<li>8명</li>
-						<li>9명</li>
-					</ul>
-					<input type='hidden' name='team' value='' />
-				</div>
-				<div>
+					<select name='team' id='team'>
+						<option value='1'>1명</option>
+						<option value='2'>2명</option>
+						<option value='3'>3명</option>
+						<option value='4'>4명</option>
+						<option value='5'>5명</option>
+						<option value='6'>6명</option>
+						<option value='7'>7명</option>
+						<option value='8'>8명</option>
+						<option value='9'>9명</option>
+					</select>
+				</RegisterFormField>
+				<RegisterFormField $direction='column' $mb={10} $fieldWidth={100} $gap={10}>
 					<label htmlFor='title'>제목</label>
 					<input type='text' name='title' value='' placeholder='제목을 입력해 주세요.' />
-				</div>
-				<div>
-					{/* 에디터 */}
-					<label htmlFor='tags'></label>
+				</RegisterFormField>
+				<EditorFormField $direction='column' $mb={10}>
+					<Editor html={editor} setHtml={setEditor} />
+					<label htmlFor='tags' className='srOnly'>
+						태그 모음
+					</label>
 					<input type='text' name='tags' value='' placeholder='#태그입력' />
-				</div>
-			</form>
+				</EditorFormField>
+				<SubmitButton>등록하기</SubmitButton>
+			</RegisterForm>
 		</ContentWrapper>
 	);
 };
 
 export default RegisterPage;
+
+const RegisterHeader = styled(StyledStack)`
+	max-width: 600px;
+	margin: 0 auto;
+	border-bottom: 1px solid #ddd;
+`;
+
+const Title = styled.h2`
+	margin-right: 8px;
+	font-size: 20px;
+`;
+
+const TitleCaption = styled.span`
+	color: #c1c1c1;
+	font-size: 13px;
+	align-self: end;
+`;
+
+const RegisterForm = styled.form`
+	max-width: 600px;
+	margin: 0 auto;
+	padding: 20px 10px;
+`;
+
+const RegisterFormField = styled(StyledStack)<{ $gap?: number; $fieldWidth?: number }>`
+	${props =>
+		props.$gap &&
+		css`
+			label {
+				${props.$direction === 'row' ? 'margin-right' : 'margin-bottom'}: ${props.$gap}px;
+			}
+		`}
+
+	label {
+		display: block;
+		min-width: 140px;
+		font-weight: 500;
+		text-align: left;
+	}
+
+	select,
+	input {
+		width: ${props => (props.$fieldWidth ? `${props.$fieldWidth}%` : '200px')};
+		padding: 6px 8px;
+		border: 1px solid #c1c1c1;
+		border-radius: 4px;
+	}
+
+	select:focus,
+	input:focus {
+		border-color: #3e86f5;
+		outline: #3e86f5;
+	}
+`;
+
+const EditorFormField = styled(StyledStack)`
+	border: 1px solid #c1c1c1;
+	border-radius: 4px;
+
+	.editor {
+		width: 100%;
+		border: none;
+	}
+
+	.ql-toolbar.ql-snow,
+	.ql-container.ql-snow {
+		position: relative;
+		border: none;
+	}
+
+	.ql-container.ql-snow {
+		min-height: 400px;
+	}
+
+	.ql-container.ql-snow::before,
+	.ql-container.ql-snow::after {
+		position: absolute;
+		left: 50%;
+		width: 96%;
+		height: 0.5px;
+		background-color: #c1c1c1;
+		transform: translateX(-50%);
+		content: '';
+	}
+
+	.ql-container.ql-snow::before {
+		top: 0;
+	}
+
+	.ql-container.ql-snow::after {
+		bottom: 0;
+	}
+
+	input {
+		position: relative;
+		top: -3px;
+		width: 100%;
+		padding: 8px 16px;
+		border: none;
+		outline: none;
+		background-color: transparent;
+	}
+`;
+
+const Calendar = styled.div`
+	position: relative;
+
+	.icon {
+		position: absolute;
+		top: 0;
+		right: -5px;
+		pointer-events: none;
+		z-index: 222;
+	}
+`;
+
+const SubmitButton = styled.button`
+	width: 100%;
+	padding: 10px;
+	border: none;
+	border-radius: 4px;
+	color: #fff;
+	background-color: #f8c332;
+	font-weight: 700;
+	font-size: 14px;
+`;

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,15 +1,14 @@
 import { BsPencil } from 'react-icons/bs';
 import styled from 'styled-components';
 
+import BoardListForm, { FormHeader, FormTitle } from '@/components/BoardListForm';
 import ContentWrapper from '@components/ContentWrapper';
-import { StyledStack } from '@/components/Stack';
 import Icon from '@/components/Icon';
-import BoardListForm from '@/components/BoardListForm';
 
 const RegisterPage = () => {
 	return (
 		<ContentWrapper>
-			<RegisterHeader $align='center' $py={10} $px={10} $mb={20}>
+			<FormHeader $align='center' $py={10} $px={10} $mb={20}>
 				<Icon
 					$variants='filled'
 					$size={24}
@@ -20,26 +19,15 @@ const RegisterPage = () => {
 				>
 					<BsPencil />
 				</Icon>
-				<Title>팀원 모집 폼</Title>
+				<FormTitle>팀원 모집 폼</FormTitle>
 				<TitleCaption>팀원을 모집하기 위해 필요한 정보이니 꼼꼼하게 입력해주세요.</TitleCaption>
-			</RegisterHeader>
+			</FormHeader>
 			<BoardListForm />
 		</ContentWrapper>
 	);
 };
 
 export default RegisterPage;
-
-const RegisterHeader = styled(StyledStack)`
-	max-width: 600px;
-	margin: 0 auto;
-	border-bottom: 1px solid #ddd;
-`;
-
-const Title = styled.h2`
-	margin-right: 8px;
-	font-size: 20px;
-`;
 
 const TitleCaption = styled.span`
 	color: #c1c1c1;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,7 +1,8 @@
 import DetailPage from './DetailPage';
 import DetailPage_owner from './DetailPage_owner';
+import EditPage from './EditPage';
 import LoginPage from './LoginPage';
 import MainPage from './MainPage';
 import RegisterPage from './RegisterPage';
 
-export { DetailPage, DetailPage_owner, LoginPage, MainPage, RegisterPage };
+export { DetailPage, DetailPage_owner, LoginPage, MainPage, RegisterPage, EditPage };

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -2,5 +2,6 @@ import DetailPage from './DetailPage';
 import DetailPage_owner from './DetailPage_owner';
 import LoginPage from './LoginPage';
 import MainPage from './MainPage';
+import RegisterPage from './RegisterPage';
 
-export { DetailPage, DetailPage_owner, LoginPage, MainPage };
+export { DetailPage, DetailPage_owner, LoginPage, MainPage, RegisterPage };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,15 @@
 		"strict": true,
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
-		"noFallthroughCasesInSwitch": true
+		"noFallthroughCasesInSwitch": true,
+
+		/* Routing Option */
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["src/*"],
+			"@components/*": ["src/components/*"],
+			"@assets/*": ["src/assets/*"]
+		}
 	},
 	"include": ["src"],
 	"references": [{ "path": "./tsconfig.node.json" }]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
 		"paths": {
 			"@/*": ["src/*"],
 			"@components/*": ["src/components/*"],
+			"@pages/*": ["src/pages/*"],
 			"@assets/*": ["src/assets/*"]
 		}
 	},

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import react from '@vitejs/plugin-react-swc';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
-})
+	plugins: [react(), tsconfigPaths()],
+});


### PR DESCRIPTION
## 개요 🧐

- 스터디, 팀 채팅에 필요한 UI 구현 및 페이지 마크업

<br>


## 작업내용 🥕
- 폰트 추가, 레이아웃 관련 공통 스타일 추가
- 레이아웃 관련 공통 컴포넌트 생성
- 등록/수정페이지 관련 공통 컴포넌트 생성
- 등록/수정이 폼 UI 생성

<br>


## To Reviewers 🙏
- 경로 가독성을 위해 alias를 추가하였습니다. (추가로 설정을 원할경우 tsconfig.json 파일에서 설정 가능합니다.)
![image](https://github.com/talktudy/front-end/assets/69078989/5f578027-758d-48d1-b650-4cf115938013)

- (참고사항) 헤더 컴포넌트 내 등록 폼을 위한 경로가 추가되었습니다.

- (참고사항) 수정페이지의 경우 임시 경로입니다, 리스트 페이지 구현 방식에 따라 달라질 수 있을거 같습니다 :)
